### PR TITLE
Update e-h version, clean up type bounds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ pkg-url = "{ repo }/releases/download/v{ version }/sx127x-util-{ target }.tgz"
 bin-dir = "{ bin }-{ target }{ format }"
 
 [features]
-util = [ "structopt", "driver-pal/hal", "simplelog", "humantime" ] 
+util = [ "structopt", "driver-pal", "driver-pal/hal", "simplelog", "humantime" ] 
 default = [ "util", "serde", "driver-pal/hal-cp2130", "driver-pal/hal-linux" ]
 
 [dependencies]
@@ -22,7 +22,7 @@ libc = "0.2"
 log = { version = "0.4" }
 bitflags = "1.0"
 
-driver-pal = { version = "0.8.0-alpha.6", default_features = false }
+driver-pal = { version = "0.8.0-alpha.6", default_features = false, optional=true }
 
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 structopt = { version = "0.3.21", optional = true }

--- a/src/base.rs
+++ b/src/base.rs
@@ -6,111 +6,39 @@
 use core::fmt::Debug;
 
 use embedded_hal::delay::blocking::{DelayUs};
-use embedded_hal::spi::blocking::Transactional;
+use embedded_hal::digital::blocking::{OutputPin, InputPin};
+use embedded_hal::spi::blocking::{Transactional, TransferInplace, Write};
 
-use driver_pal::{Reset, Busy, PinState, PrefixRead, PrefixWrite};
 use driver_pal::Error as WrapError;
 
-use crate::Error;
+/// HAL trait for radio interaction, may be generic over SPI or UART connections
+pub trait Hal {
+    type Error: Debug + 'static;
 
-/// Base implementation can be generic over SPI or UART connections
-pub trait Base<CommsError, PinError, DelayError> {
     /// Reset the device
-    fn reset(&mut self) -> Result<(), Error<CommsError, PinError, DelayError>>;
+    fn reset(&mut self) -> Result<(), Self::Error>;
 
     /// Wait on radio device busy
-    fn wait_busy(&mut self) -> Result<(), Error<CommsError, PinError, DelayError>>;
+    fn wait_busy(&mut self) -> Result<(), Self::Error>;
 
     /// Delay for the specified time
-    fn delay_ms(&mut self, ms: u32) -> Result<(), DelayError>;
+    fn delay_ms(&mut self, ms: u32) -> Result<(), Self::Error>;
 
     /// Delay for the specified time
-    fn delay_us(&mut self, us: u32) -> Result<(), DelayError>;
+    fn delay_us(&mut self, us: u32) -> Result<(), Self::Error>;
 
-    /// Write a slice of data to the specified register
-    fn write_regs(&mut self, reg: u8, data: &[u8]) -> Result<(), Error<CommsError, PinError, DelayError>>;
-    /// Read a slice of data from the specified register
-    fn read_regs(&mut self, reg: u8, data: &mut [u8]) -> Result<(), Error<CommsError, PinError, DelayError>>;
+    /// Read from radio with prefix
+    fn prefix_read(&mut self, prefix: &[u8], data: &mut [u8]) -> Result<(), Self::Error>;
 
-    /// Write to the specified FIFO buffer
-    fn write_buff(&mut self, data: &[u8]) -> Result<(), Error<CommsError, PinError, DelayError>>;
-    /// Read from the specified FIFO buffer
-    fn read_buff(&mut self, data: &mut [u8]) -> Result<(), Error<CommsError, PinError, DelayError>>;
+    /// Write to radio with prefix
+    fn prefix_write(&mut self, prefix: &[u8], data: &[u8]) -> Result<(), Self::Error>;
 
-    /// Read a single u8 value from the specified register
-    fn read_reg(&mut self, reg: u8) -> Result<u8, Error<CommsError, PinError, DelayError>> {
-        let mut incoming = [0u8; 1];
-        self.read_regs(reg.into(), &mut incoming)?;
-        Ok(incoming[0])
-    }
-
-    /// Write a single u8 value to the specified register
-    fn write_reg(&mut self, reg: u8, value: u8) -> Result<(), Error<CommsError, PinError, DelayError>> {
-        self.write_regs(reg.into(), &[value])?;
-        Ok(())
-    }
-
-    /// Update the specified register with the provided value & mask
-    fn update_reg(
-        &mut self,
-        reg: u8,
-        mask: u8,
-        value: u8,
-    ) -> Result<u8, Error<CommsError, PinError, DelayError>> {
-        let existing = self.read_reg(reg)?;
-        let updated = (existing & !mask) | (value & mask);
-        self.write_reg(reg, updated)?;
-        Ok(updated)
-    }
-}
-
-/// Implement HAL for embedded helper trait implementers
-impl<T, CommsError, PinError, DelayError> Base<CommsError, PinError, DelayError> for T
-where
-    T: Transactional<u8, Error = WrapError<CommsError, PinError, DelayError>> 
-            + PrefixRead<Error=WrapError<CommsError, PinError, DelayError>> 
-            + PrefixWrite<Error=WrapError<CommsError, PinError, DelayError>>,
-    T: Reset<Error = PinError>,
-    T: Busy<Error = PinError>,
-    T: DelayUs<Error=DelayError>,
-    CommsError: Debug + Sync + Send + 'static,
-    PinError: Debug + Sync + Send + 'static,
-    DelayError: Debug + Sync + Send + 'static,
-{
-    /// Reset the radio
-    fn reset(&mut self) -> Result<(), Error<CommsError, PinError, DelayError>> {
-        self.set_reset(PinState::Low).map_err(WrapError::Pin)?;
-        self.delay_ms(1).map_err(WrapError::Delay)?;
-        self.set_reset(PinState::High).map_err(WrapError::Pin)?;
-        self.delay_ms(10).map_err(WrapError::Delay)?;
-
-        Ok(())
-    }
-
-    /// Wait on radio device busy
-    fn wait_busy(&mut self) -> Result<(), Error<CommsError, PinError, DelayError>> {
-        // TODO: suspiciously unimplemented?!
-        Ok(())
-    }
-
-    /// Delay for the specified time
-    fn delay_ms(&mut self, ms: u32) -> Result<(), DelayError> {
-        DelayUs::delay_ms(self, ms)?;
-        Ok(())
-    }
-
-    /// Delay for the specified time
-    fn delay_us(&mut self, us: u32) -> Result<(), DelayError> {
-        DelayUs::delay_us(self, us)?;
-        Ok(())
-    }
-
-    /// Read from the specified register
-    fn read_regs<'a>(
-        &mut self,
-        reg: u8,
-        data: &mut [u8],
-    ) -> Result<(), Error<CommsError, PinError, DelayError>> {
+   /// Read from the specified register
+   fn read_regs<'a>(
+    &mut self,
+    reg: u8,
+    data: &mut [u8],
+    ) -> Result<(), Self::Error> {
         // Setup register read
         let out_buf: [u8; 1] = [reg as u8 & 0x7F];
         self.wait_busy()?;
@@ -123,7 +51,7 @@ where
     }
 
     /// Write to the specified register
-    fn write_regs(&mut self, reg: u8, data: &[u8]) -> Result<(), Error<CommsError, PinError, DelayError>> {
+    fn write_regs(&mut self, reg: u8, data: &[u8]) -> Result<(), Self::Error> {
         // Setup register write
         let out_buf: [u8; 1] = [reg as u8 | 0x80];
         self.wait_busy()?;
@@ -133,7 +61,7 @@ where
     }
 
     /// Write to the specified buffer
-    fn write_buff(&mut self, data: &[u8]) -> Result<(), Error<CommsError, PinError, DelayError>> {
+    fn write_buff(&mut self, data: &[u8]) -> Result<(), Self::Error> {
         // Setup fifo buffer write
         let out_buf: [u8; 1] = [0x00 | 0x80];
         self.wait_busy()?;
@@ -143,7 +71,7 @@ where
     }
 
     /// Read from the specified buffer
-    fn read_buff<'a>(&mut self, data: &mut [u8]) -> Result<(), Error<CommsError, PinError, DelayError>> {
+    fn read_buff<'a>(&mut self, data: &mut [u8]) -> Result<(), Self::Error> {
         // Setup fifo buffer read
         let out_buf: [u8; 1] = [0x00];
         self.wait_busy()?;
@@ -153,5 +81,127 @@ where
             .map_err(|e| e.into());
         self.wait_busy()?;
         r
+    }
+
+    /// Read a single u8 value from the specified register
+    fn read_reg(&mut self, reg: u8) -> Result<u8, Self::Error> {
+        let mut incoming = [0u8; 1];
+        self.read_regs(reg.into(), &mut incoming)?;
+        Ok(incoming[0])
+    }
+
+    /// Write a single u8 value to the specified register
+    fn write_reg(&mut self, reg: u8, value: u8) -> Result<(), Self::Error> {
+        self.write_regs(reg.into(), &[value])?;
+        Ok(())
+    }
+
+    /// Update the specified register with the provided value & mask
+    fn update_reg(
+        &mut self,
+        reg: u8,
+        mask: u8,
+        value: u8,
+    ) -> Result<u8, Self::Error> {
+        let existing = self.read_reg(reg)?;
+        let updated = (existing & !mask) | (value & mask);
+        self.write_reg(reg, updated)?;
+        Ok(updated)
+    }
+}
+
+/// Helper SPI trait to tie errors together (no longer required next HAL release)
+pub trait SpiBase: TransferInplace<u8, Error = <Self as SpiBase>::Error> + Write<u8, Error = <Self as SpiBase>::Error> + Transactional<u8, Error = <Self as SpiBase>::Error> {
+    type Error;
+}
+
+impl <T: TransferInplace<u8, Error = E> + Write<u8, Error = E> + Transactional<u8, Error = E>, E> SpiBase for T {
+    type Error = E;
+}
+
+/// Spi base object defined interface for interacting with radio via SPI
+pub struct Base <Spi: SpiBase, Cs: OutputPin, Busy: InputPin, Ready: InputPin, Sdn: OutputPin, Delay: DelayUs> {
+    pub spi: Spi,
+    pub cs: Cs,
+    pub busy: Busy,
+    pub ready: Ready,
+    pub sdn: Sdn,
+    pub delay: Delay,
+}
+
+/// Implement HAL for base object
+impl<Spi, Cs, Busy, Ready, Sdn, PinError, Delay> Hal for Base<Spi, Cs, Busy, Ready, Sdn, Delay>
+where
+    Spi: SpiBase,
+    <Spi as SpiBase>::Error: Debug + 'static,
+    
+    Cs: OutputPin<Error=PinError>,
+    Busy: InputPin<Error=PinError>,
+    Ready: InputPin<Error=PinError>,
+    Sdn: OutputPin<Error=PinError>,
+    PinError: Debug + 'static,
+
+    Delay: DelayUs,
+    <Delay as DelayUs>::Error: Debug + 'static,
+{
+    type Error = WrapError<<Spi as SpiBase>::Error, PinError, <Delay as DelayUs>::Error>;
+
+    /// Reset the radio
+    fn reset(&mut self) -> Result<(), Self::Error> {
+        self.sdn.set_low().map_err(WrapError::Pin)?;
+
+        self.delay.delay_ms(1).map_err(WrapError::Delay)?;
+
+        self.sdn.set_high().map_err(WrapError::Pin)?;
+
+        self.delay.delay_ms(10).map_err(WrapError::Delay)?;
+
+        Ok(())
+    }
+
+    /// Wait on radio device busy
+    fn wait_busy(&mut self) -> Result<(), Self::Error> {
+        // TODO: suspiciously unimplemented?!
+        Ok(())
+    }
+
+    /// Delay for the specified time
+    fn delay_ms(&mut self, ms: u32) -> Result<(), Self::Error> {
+        self.delay.delay_ms(ms).map_err(WrapError::Delay)?;
+        Ok(())
+    }
+
+    /// Delay for the specified time
+    fn delay_us(&mut self, us: u32) -> Result<(), Self::Error> {
+        self.delay.delay_us(us).map_err(WrapError::Delay)?;
+        Ok(())
+    }
+
+    /// Write data with prefix, asserting CS as required
+    fn prefix_write(&mut self, prefix: &[u8], data: &[u8]) -> Result<(), Self::Error> {
+        self.cs.set_low().map_err(WrapError::Pin)?;
+
+        let r = self.spi.write(prefix).map(|_| self.spi.write(data));
+
+        self.cs.set_high().map_err(WrapError::Pin)?;
+
+        match r {
+            Ok(Ok(_)) => Ok(()),
+            Ok(Err(e)) | Err(e) => Err(WrapError::Spi(e)),
+        }
+    }
+
+    /// Read data with prefix, asserting CS as required
+    fn prefix_read(&mut self, prefix: &[u8], data: &mut [u8]) -> Result<(), Self::Error> {
+        self.cs.set_low().map_err(WrapError::Pin)?;
+
+        let r = self.spi.write(prefix).map(|_| self.spi.transfer_inplace(data));
+
+        self.cs.set_high().map_err(WrapError::Pin)?;
+
+        match r {
+            Ok(Ok(_)) => Ok(()),
+            Ok(Err(e)) | Err(e) => Err(WrapError::Spi(e)),
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,17 +12,14 @@
 use core::convert::TryFrom;
 use core::fmt::Debug;
 
-use base::{Base, SpiBase};
+use base::{Base, SpiBase, HalError};
 use log::{trace, debug, warn};
 
 use embedded_hal::spi::{Mode as SpiMode, Phase, Polarity};
 use embedded_hal::delay::blocking::{DelayUs};
 use embedded_hal::digital::blocking::{InputPin, OutputPin};
 
-use driver_pal::{Error as WrapError};
-
 use radio::{Power as _, State as _};
-
 
 pub mod base;
 
@@ -128,7 +125,7 @@ where
         sdn: SdnPin,
         delay: Delay,
         config: &Config,
-    ) -> Result<Self, Error<WrapError<<Spi as SpiBase>::Error, PinError, <Delay as DelayUs>::Error>>> {
+    ) -> Result<Self, Error<HalError<<Spi as SpiBase>::Error, PinError, <Delay as DelayUs>::Error>>> {
         // Create SpiWrapper over spi/cs/busy/ready/reset
         let base = Base{spi, cs, sdn, busy, ready, delay};
 

--- a/src/lora.rs
+++ b/src/lora.rs
@@ -4,30 +4,25 @@
 //!
 //! Copyright 2019 Ryan Kurte
 
-use core::fmt::Debug;
-
 use log::{trace, debug, warn, error};
 
 use radio::State as _;
 
-use crate::base::Base as Sx127xBase;
+use crate::base;
 use crate::device::lora::*;
 use crate::device::{self, regs, Channel, Modem, ModemMode, PacketInfo, State};
 use crate::{Error, Mode, Sx127x};
 
-impl<Base, CommsError, PinError, DelayError> Sx127x<Base, CommsError, PinError, DelayError>
+impl<Hal> Sx127x<Hal>
 where
-    Base: Sx127xBase<CommsError, PinError, DelayError>,
-    CommsError: Debug + Sync + Send + 'static,
-    PinError: Debug + Sync + Send + 'static,
-    DelayError: Debug + Sync + Send + 'static,
+    Hal: base::Hal,
 {
     /// Configure the radio in lora mode with the provided configuration and channel
     pub(crate) fn lora_configure(
         &mut self,
         config: &LoRaConfig,
         channel: &LoRaChannel,
-    ) -> Result<(), Error<CommsError, PinError, DelayError>> {
+    ) -> Result<(), Error<<Hal as base::Hal>::Error>> {
         debug!("Configuring lora mode");
 
         // Update internal config
@@ -121,7 +116,7 @@ where
     pub(crate) fn lora_get_interrupts(
         &mut self,
         clear: bool,
-    ) -> Result<Irq, Error<CommsError, PinError, DelayError>> {
+    ) -> Result<Irq, Error<<Hal as base::Hal>::Error>> {
         let reg = self.read_reg(regs::LoRa::IRQFLAGS)?;
         let irq = Irq::from_bits(reg).unwrap();
 
@@ -136,7 +131,7 @@ where
     pub(crate) fn lora_set_channel(
         &mut self,
         channel: &LoRaChannel,
-    ) -> Result<(), Error<CommsError, PinError, DelayError>> {
+    ) -> Result<(), Error<<Hal as base::Hal>::Error>> {
         use device::lora::{Bandwidth::*, SpreadingFactor::*};
 
         // Set the frequency
@@ -219,7 +214,7 @@ where
     pub(crate) fn lora_start_transmit(
         &mut self,
         data: &[u8],
-    ) -> Result<(), Error<CommsError, PinError, DelayError>> {
+    ) -> Result<(), Error<<Hal as base::Hal>::Error>> {
         debug!("Starting send (data: {:?})", data);
 
         // TODO: support large packet sending
@@ -269,7 +264,7 @@ where
     /// Check for transmission completion
     /// This method should be polled (or checked following and interrupt) to indicate sending
     /// has completed
-    pub(crate) fn lora_check_transmit(&mut self) -> Result<bool, Error<CommsError, PinError, DelayError>> {
+    pub(crate) fn lora_check_transmit(&mut self) -> Result<bool, Error<<Hal as base::Hal>::Error>> {
         let irq = self.lora_get_interrupts(true)?;
         trace!("Poll check send, irq: {:?}", irq);
 
@@ -283,7 +278,7 @@ where
     }
 
     /// Start receive mode
-    pub(crate) fn lora_start_receive(&mut self) -> Result<(), Error<CommsError, PinError, DelayError>> {
+    pub(crate) fn lora_start_receive(&mut self) -> Result<(), Error<<Hal as base::Hal>::Error>> {
         use device::lora::Bandwidth::*;
 
         debug!("Starting receive");
@@ -346,7 +341,7 @@ where
     pub(crate) fn lora_check_receive(
         &mut self,
         restart: bool,
-    ) -> Result<bool, Error<CommsError, PinError, DelayError>> {
+    ) -> Result<bool, Error<<Hal as base::Hal>::Error>> {
         let irq = self.lora_get_interrupts(true)?;
         let mut res = Ok(false);
 
@@ -392,7 +387,7 @@ where
     pub(crate) fn lora_get_received(
         &mut self,
         data: &mut [u8],
-    ) -> Result<(usize, PacketInfo), Error<CommsError, PinError, DelayError>> {
+    ) -> Result<(usize, PacketInfo), Error<<Hal as base::Hal>::Error>> {
         // Fetch the number of bytes and current RX address pointer
         let n = self.read_reg(regs::LoRa::RXNBBYTES)? as usize;
         let r = self.read_reg(regs::LoRa::FIFORXCURRENTADDR)?;
@@ -430,7 +425,7 @@ where
 
     /// Poll for the current channel RSSI
     /// This should only be called in receive mode
-    pub(crate) fn lora_poll_rssi(&mut self) -> Result<i16, Error<CommsError, PinError, DelayError>> {
+    pub(crate) fn lora_poll_rssi(&mut self) -> Result<i16, Error<<Hal as base::Hal>::Error>> {
         let raw = self.read_reg(regs::LoRa::RSSIVALUE)?;
 
         // TODO: hf/lf port switch


### PR DESCRIPTION
hopefully this makes it a bunch simpler for folks using this crate (see https://github.com/rust-iot/rust-radio-sx127x/issues/38)

similar to https://github.com/rust-iot/rust-radio-sx128x/pull/105, though i tried a different method of erasing errors which reduces the type constraints.